### PR TITLE
Set up separate hurtboxes from environmental hitboxes

### DIFF
--- a/Actors/Characters/Character.gd
+++ b/Actors/Characters/Character.gd
@@ -17,7 +17,7 @@ var hp
 # Called when the node enters the scene tree for the first time.
 func _ready():
     hp = max_hp
-    add_to_group("characters")
+    $Hurtbox.add_to_group("characters")
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Actors/Characters/Enemy/Enemy.tscn
+++ b/Actors/Characters/Enemy/Enemy.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Actors/Characters/Enemy/Enemy.gd" type="Script" id=1]
 
 [sub_resource type="CapsuleShape2D" id=1]
+
+[sub_resource type="CapsuleShape2D" id=2]
 
 [node name="Enemy" type="KinematicBody2D"]
 collision_layer = 2
@@ -25,6 +27,13 @@ autostart = true
 
 [node name="ShootTimer" type="Timer" parent="."]
 autostart = true
+
+[node name="Hurtbox" type="Area2D" parent="."]
+collision_layer = 2
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource( 2 )
 [connection signal="timeout" from="RunTimer" to="." method="_on_Timer_timeout"]
 [connection signal="timeout" from="JumpTimer" to="." method="_on_JumpTimer_timeout"]
 [connection signal="timeout" from="ShootTimer" to="." method="_on_ShootTimer_timeout"]

--- a/Actors/Characters/Player/Player.tscn
+++ b/Actors/Characters/Player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Actors/Characters/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Actors/Characters/Player/cat1193.jpg" type="Texture" id=2]
@@ -6,8 +6,13 @@
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 128, 128 )
 
+[sub_resource type="CircleShape2D" id=2]
+radius = 50.0
+
 [node name="Kinematic2D" type="KinematicBody2D"]
 scale = Vector2( 0.15, 0.15 )
+collision_layer = 2
+collision_mask = 2
 script = ExtResource( 1 )
 run_speed = 400
 jump_speed = -500
@@ -32,3 +37,8 @@ collide_with_areas = true
 current = true
 drag_margin_h_enabled = true
 drag_margin_v_enabled = true
+
+[node name="Hurtbox" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource( 2 )

--- a/Actors/Projectiles/Bullet.gd
+++ b/Actors/Projectiles/Bullet.gd
@@ -30,7 +30,6 @@ func _on_screen_exited():
     queue_free()
     
 func _on_area_enter(area):
-    print(area)
     if area.is_in_group("characters"):
         area.owner.get_hit(damage)
     

--- a/Actors/Projectiles/Bullet.gd
+++ b/Actors/Projectiles/Bullet.gd
@@ -20,7 +20,7 @@ func start(pos, dir, player_bullet):
 # Called when the node enters the scene tree for the first time.
 func _ready():
     get_node("VisibilityNotifier2D").connect("screen_exited", self, "_on_screen_exited")
-    connect("body_entered", self, "_on_body_enter")
+    connect("area_entered", self, "_on_area_enter")
 
 
 func _process(delta):
@@ -29,9 +29,10 @@ func _process(delta):
 func _on_screen_exited():
     queue_free()
     
-func _on_body_enter(body):
-    if body.is_in_group("characters"):
-        body.get_hit(damage)
+func _on_area_enter(area):
+    print(area)
+    if area.is_in_group("characters"):
+        area.owner.get_hit(damage)
     
     queue_free()
 


### PR DESCRIPTION
Player and enemy hurtboxes are now separate Area2Ds called "Hurtbox".
These Area2Ds must be direct children of the KinematicBody in order for
the bullet hit detection to work.