### PR TITLE
is_dark also toggles player environmental hitbox

### DIFF
--- a/Actors/Characters/Player/Player.gd
+++ b/Actors/Characters/Player/Player.gd
@@ -74,6 +74,9 @@ func _process(delta):
     # Update mask for light & dark layer bullet collisions.
     $Hurtbox.set_collision_layer_bit(0, not ModeManager.is_dark)
     $Hurtbox.set_collision_layer_bit(2, ModeManager.is_dark)
+    set_collision_layer_bit(0, not ModeManager.is_dark)
+    set_collision_layer_bit(2, ModeManager.is_dark)
+    print(str(get_collision_layer_bit(0)) + " " + str(get_collision_layer_bit(2)))
 
 func _on_RedPowerUp_powerup():
     shoot_cooldown = shoot_cooldown / 2

--- a/Actors/Characters/Player/Player.gd
+++ b/Actors/Characters/Player/Player.gd
@@ -76,7 +76,6 @@ func _process(delta):
     $Hurtbox.set_collision_layer_bit(2, ModeManager.is_dark)
     set_collision_layer_bit(0, not ModeManager.is_dark)
     set_collision_layer_bit(2, ModeManager.is_dark)
-    print(str(get_collision_layer_bit(0)) + " " + str(get_collision_layer_bit(2)))
 
 func _on_RedPowerUp_powerup():
     shoot_cooldown = shoot_cooldown / 2

--- a/Levels/Level.tscn
+++ b/Levels/Level.tscn
@@ -39,14 +39,14 @@ collision_layer = 3
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
-position = Vector2( 485.932, 426.741 )
+position = Vector2( 483.932, 426.741 )
 shape = SubResource( 1 )
 
 [node name="Platforms" type="Node" parent="."]
 
 [node name="Platform" parent="Platforms" instance=ExtResource( 2 )]
 position = Vector2( 840, 350 )
-collision_mask = 3
+collision_layer = 0
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Platforms/Platform"]
 autoplay = "move"


### PR DESCRIPTION
this allows for terrain that only supports the player when is_dark is
true, or vice versa.