### PR TITLE
Add a boss HP bar that only shows up when you enter the arena

### DIFF
--- a/Actors/Projectiles/Bullet.gd
+++ b/Actors/Projectiles/Bullet.gd
@@ -41,8 +41,7 @@ func _on_screen_exited():
 func _on_area_enter(area):
     if area.is_in_group("characters"):
         area.owner.get_hit(damage)
-    
-    queue_free()
+        queue_free()
     
 func _on_body_enter(body):
     if body is TileMap:

--- a/Actors/Projectiles/MultiBullet.tscn
+++ b/Actors/Projectiles/MultiBullet.tscn
@@ -25,6 +25,5 @@ shape = SubResource( 1 )
 
 [node name="Timer" type="Timer" parent="."]
 wait_time = 0.25
-one_shot = true
 autostart = true
 [connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]

--- a/GUI.gd
+++ b/GUI.gd
@@ -1,14 +1,23 @@
-extends MarginContainer
+extends CanvasLayer
 
 
 onready var hp_bar = $HpBar
+onready var boss_hp_bar = $BossHpBar
+onready var player = $"../Player"
+onready var boss = $"../Boss"
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-    var player = $"../../Player"
-    hp_bar.max_value = player.max_hp
-    hp_bar.value = player.hp
+    if player != null:
+        hp_bar.max_value = player.max_hp
+        hp_bar.value = player.hp
+    else:
+        hp_bar.hide()
+    if boss != null:
+        boss_hp_bar.max_value = boss.max_hp
+        boss_hp_bar.value = boss.hp
+    boss_hp_bar.hide()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -17,5 +26,20 @@ func _ready():
 
 
 func _on_Player_health_changed(player_health):
-    print(player_health)
     hp_bar.value = player_health
+
+
+func _on_BossArena_body_entered(body):
+    print(body)
+    if body == player:
+        print("is player")
+        boss_hp_bar.show()
+
+
+func _on_BossArena_body_exited(body):
+    if body == player:
+        boss_hp_bar.hide()
+
+
+func _on_Boss_health_changed(boss_health):
+    boss_hp_bar.value = boss_health

--- a/GUI.tscn
+++ b/GUI.tscn
@@ -1,17 +1,32 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://GUI.gd" type="Script" id=1]
 [ext_resource path="res://assets/GUI/lifebar_fill.png" type="Texture" id=2]
 [ext_resource path="res://assets/GUI/lifebar_bg.png" type="Texture" id=3]
+[ext_resource path="res://assets/fonts/Xolonium-Regular.ttf" type="DynamicFontData" id=4]
 
-[node name="GUI" type="MarginContainer"]
-margin_right = 1024.0
-margin_bottom = 41.0
-custom_constants/margin_right = 20
-custom_constants/margin_top = 20
-custom_constants/margin_left = 20
-custom_constants/margin_bottom = 20
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 1, 0, 0, 1 )
+
+[sub_resource type="DynamicFont" id=2]
+size = 28
+font_data = ExtResource( 4 )
+
+[node name="CanvasLayer" type="CanvasLayer"]
 script = ExtResource( 1 )
+
+[node name="BossHpBar" type="ProgressBar" parent="."]
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -565.0
+margin_top = -54.0168
+margin_right = 565.0
+margin_bottom = -15.0168
+custom_styles/fg = SubResource( 1 )
+custom_fonts/font = SubResource( 2 )
+value = 100.0
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/Levels/Level.tscn
+++ b/Levels/Level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://Actors/Characters/Player/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Platforms/Platforms.tscn" type="PackedScene" id=2]
@@ -28,6 +28,9 @@ tracks/0/keys = {
 "update": 0,
 "values": [ Vector2( 840, 350 ), Vector2( 840, 180 ) ]
 }
+
+[sub_resource type="RectangleShape2D" id=3]
+extents = Vector2( 928.966, 561.962 )
 
 [node name="Level" type="Node2D"]
 
@@ -76,7 +79,16 @@ position = Vector2( 553.999, 106.972 )
 run_speed = 0
 max_hp = 5000
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
+[node name="GUI" parent="." instance=ExtResource( 8 )]
 
-[node name="GUI" parent="CanvasLayer" instance=ExtResource( 8 )]
-[connection signal="health_changed" from="Player" to="CanvasLayer/GUI" method="_on_Player_health_changed"]
+[node name="BossArena" type="Area2D" parent="."]
+collision_layer = 7
+collision_mask = 7
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BossArena"]
+position = Vector2( 559.901, 383.259 )
+shape = SubResource( 3 )
+[connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]
+[connection signal="body_entered" from="BossArena" to="GUI" method="_on_BossArena_body_entered"]
+[connection signal="body_exited" from="BossArena" to="GUI" method="_on_BossArena_body_exited"]

--- a/Levels/Level1.tscn
+++ b/Levels/Level1.tscn
@@ -65,10 +65,18 @@ position = Vector2( 1780, 600 )
 autoplay = "move"
 anims/move = SubResource( 1 )
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="GUI" parent="CanvasLayer" instance=ExtResource( 7 )]
-
 [node name="PauseMenu" parent="." instance=ExtResource( 8 )]
-[connection signal="health_changed" from="Player" to="CanvasLayer/GUI" method="_on_Player_health_changed"]
+
+[node name="GUI" parent="." instance=ExtResource( 7 )]
+
+[node name="BossArena" type="Area2D" parent="."]
+collision_layer = 5
+collision_mask = 5
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="BossArena"]
+polygon = PoolVector2Array( -14.2405, 690.458, 1455.13, 693.287, 1460, 1022.67, 1502.04, 1023.33, 1504.05, 1096.08, -10.4035, 1103.04 )
+[connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]
 [connection signal="powerup" from="RedPowerUp" to="Player" method="_on_RedPowerUp_powerup"]
+[connection signal="body_entered" from="BossArena" to="GUI" method="_on_BossArena_body_entered"]
+[connection signal="body_exited" from="BossArena" to="GUI" method="_on_BossArena_body_exited"]

--- a/Levels/LevelBattlefield.tscn
+++ b/Levels/LevelBattlefield.tscn
@@ -14,9 +14,7 @@ tile_data = PoolIntArray( 196614, 0, 5, 196615, 0, 6, 196616, 0, 6, 196617, 0, 7
 [node name="Player" parent="." instance=ExtResource( 2 )]
 position = Vector2( 531.687, 428.373 )
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="GUI" parent="CanvasLayer" instance=ExtResource( 3 )]
-
 [node name="PauseMenu" parent="." instance=ExtResource( 4 )]
-[connection signal="health_changed" from="Player" to="CanvasLayer/GUI" method="_on_Player_health_changed"]
+
+[node name="GUI" parent="." instance=ExtResource( 3 )]
+[connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]

--- a/Levels/LevelSmashville.tscn
+++ b/Levels/LevelSmashville.tscn
@@ -38,9 +38,7 @@ position = Vector2( 250, 274 )
 autoplay = "move"
 anims/move = SubResource( 1 )
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="GUI" parent="CanvasLayer" instance=ExtResource( 4 )]
-
 [node name="PauseMenu" parent="." instance=ExtResource( 5 )]
-[connection signal="health_changed" from="Player" to="CanvasLayer/GUI" method="_on_Player_health_changed"]
+
+[node name="GUI" parent="." instance=ExtResource( 4 )]
+[connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]


### PR DESCRIPTION
The boss hp bar is a part of the GUI. If a level has a boss, it must
define an Area2d for the boss arena and hook up the body_entered signal
to the GUI. Also, the boss's health_changed signal must be connected to
the GUI.

Also, the CanvasLayer that the GUI used to be placed in has been moved
into the GUI scene. Thus, the GUI should be a direct child of the root
node in level scenes. Also, the boss and player nodes must be siblings
of the GUI node for the GUI to work correctly.