### PR TITLE
Fix kill floor, fix pause screen

### DIFF
--- a/Actors/Characters/Player/Player.gd
+++ b/Actors/Characters/Player/Player.gd
@@ -106,7 +106,8 @@ func _on_RedPowerUp_powerup():
 
 
 func _on_Kill_Floor_area_entered(area):
-    get_hit(69420)
+    if area == $Hurtbox:
+        get_hit(69420)
     
 func get_hit(damage):
     if (hp - damage <= 0):

--- a/Actors/Characters/Player/Player.tscn
+++ b/Actors/Characters/Player/Player.tscn
@@ -52,48 +52,48 @@ atlas = ExtResource( 3 )
 region = Rect2( 192, 68, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=13]
-atlas = ExtResource( 3 )
-region = Rect2( 192, 136, 64, 68 )
-
-[sub_resource type="AtlasTexture" id=14]
 atlas = ExtResource( 4 )
 region = Rect2( 0, 0, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=15]
+[sub_resource type="AtlasTexture" id=14]
 atlas = ExtResource( 4 )
 region = Rect2( 59, 0, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=16]
+[sub_resource type="AtlasTexture" id=15]
 atlas = ExtResource( 4 )
 region = Rect2( 118, 0, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=17]
+[sub_resource type="AtlasTexture" id=16]
 atlas = ExtResource( 4 )
 region = Rect2( 177, 0, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=18]
+[sub_resource type="AtlasTexture" id=17]
 atlas = ExtResource( 4 )
 region = Rect2( 236, 0, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=19]
+[sub_resource type="AtlasTexture" id=18]
 atlas = ExtResource( 4 )
 region = Rect2( 0, 59, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=20]
+[sub_resource type="AtlasTexture" id=19]
 atlas = ExtResource( 4 )
 region = Rect2( 59, 59, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=21]
+[sub_resource type="AtlasTexture" id=20]
 atlas = ExtResource( 4 )
 region = Rect2( 118, 59, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=22]
+[sub_resource type="AtlasTexture" id=21]
 atlas = ExtResource( 4 )
 region = Rect2( 177, 59, 59, 59 )
 
-[sub_resource type="AtlasTexture" id=23]
+[sub_resource type="AtlasTexture" id=22]
 atlas = ExtResource( 4 )
 region = Rect2( 236, 59, 59, 59 )
+
+[sub_resource type="AtlasTexture" id=23]
+atlas = ExtResource( 3 )
+region = Rect2( 192, 136, 64, 68 )
 
 [sub_resource type="SpriteFrames" id=24]
 animations = [ {
@@ -112,15 +112,15 @@ animations = [ {
 "name": "walk",
 "speed": 12.0
 }, {
-"frames": [ SubResource( 13 ) ],
-"loop": true,
-"name": "airborne",
-"speed": 5.0
-}, {
-"frames": [ SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ) ],
+"frames": [ SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ) ],
 "loop": false,
 "name": "die",
 "speed": 20.0
+}, {
+"frames": [ SubResource( 23 ) ],
+"loop": true,
+"name": "airborne",
+"speed": 5.0
 } ]
 
 [node name="Kinematic2D" type="KinematicBody2D"]

--- a/Levels/Level.tscn
+++ b/Levels/Level.tscn
@@ -29,6 +29,7 @@ tracks/0/keys = {
 }
 
 [sub_resource type="RectangleShape2D" id=3]
+extents = Vector2( 27.1948, 20.8566 )
 
 [node name="Level" type="Node2D"]
 script = ExtResource( 9 )
@@ -73,6 +74,7 @@ position = Vector2( 556.294, 491.714 )
 scale = Vector2( -61.8083, -4.77283 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Kill Floor"]
+position = Vector2( 0, -39.5991 )
 shape = SubResource( 3 )
 [connection signal="body_entered" from="BossArena" to="GUI" method="_on_BossArena_body_entered"]
 [connection signal="body_exited" from="BossArena" to="GUI" method="_on_BossArena_body_exited"]

--- a/Levels/Level1.tscn
+++ b/Levels/Level1.tscn
@@ -69,6 +69,7 @@ autoplay = "move"
 anims/move = SubResource( 1 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 8 )]
+pause_mode = 2
 
 [node name="GUI" parent="." instance=ExtResource( 7 )]
 

--- a/Levels/LevelSmashville.tscn
+++ b/Levels/LevelSmashville.tscn
@@ -40,6 +40,7 @@ autoplay = "move"
 anims/move = SubResource( 1 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 5 )]
+pause_mode = 2
 
 [node name="GUI" parent="." instance=ExtResource( 4 )]
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]

--- a/PauseMenu.gd
+++ b/PauseMenu.gd
@@ -4,6 +4,8 @@ extends CanvasLayer
 # Called when the node enters the scene tree for the first time.
 func _ready():
     $Control.hide()
+    # make sure pausing doesn't disable the pause screen
+    pause_mode = Node.PAUSE_MODE_PROCESS
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):


### PR DESCRIPTION
kill floor was triggering player death any time ANY area entered it. I
added a check to make sure only the player hurtbox would trigger this.

Also, I changed the pause menu script to ensure the pause menu would
initialize with pause mode set to PROCESS, preventing the pause menu
from being paused (which would disable unpausing). Also, just to be
safe, I manually set the pause menu node's pause mode to PROCESS in all
scenes with a pause menu.