### PR TITLE
Camera now stops where the player died

### DIFF
--- a/Actors/Characters/Player/Player.gd
+++ b/Actors/Characters/Player/Player.gd
@@ -22,6 +22,8 @@ var is_facing_left = false
 
 onready var animation_player = $AnimatedSprite
 
+signal player_killed
+
 func _ready():
     add_to_group("Player")
     animation_player.play("default")
@@ -65,6 +67,7 @@ func get_movement_input():
             animation_player.play("jump")
             velocity.y = jump_speed
         elif (not has_used_double_jump):
+            animation_player.frame = 0
             animation_player.play("jump")
             has_used_double_jump = true
             velocity.y = jump_speed
@@ -113,5 +116,6 @@ func get_hit(damage):
     if (hp - damage <= 0):
         animation_player.play("die")
         yield(animation_player, "animation_finished")
+        emit_signal("player_killed", $Camera2D.get_camera_position())
     
     .get_hit(damage)

--- a/Actors/Characters/Player/Player.tscn
+++ b/Actors/Characters/Player/Player.tscn
@@ -29,71 +29,71 @@ region = Rect2( 192, 136, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=7]
 atlas = ExtResource( 3 )
-region = Rect2( 64, 68, 64, 68 )
+region = Rect2( 192, 136, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=8]
 atlas = ExtResource( 3 )
-region = Rect2( 64, 0, 64, 68 )
+region = Rect2( 64, 68, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=9]
 atlas = ExtResource( 3 )
-region = Rect2( 128, 0, 64, 68 )
+region = Rect2( 64, 0, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=10]
 atlas = ExtResource( 3 )
-region = Rect2( 192, 0, 64, 68 )
+region = Rect2( 128, 0, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=11]
 atlas = ExtResource( 3 )
-region = Rect2( 128, 68, 64, 68 )
+region = Rect2( 192, 0, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=12]
 atlas = ExtResource( 3 )
-region = Rect2( 192, 68, 64, 68 )
+region = Rect2( 128, 68, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=13]
-atlas = ExtResource( 4 )
-region = Rect2( 0, 0, 59, 59 )
+atlas = ExtResource( 3 )
+region = Rect2( 192, 68, 64, 68 )
 
 [sub_resource type="AtlasTexture" id=14]
 atlas = ExtResource( 4 )
-region = Rect2( 59, 0, 59, 59 )
+region = Rect2( 0, 0, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=15]
 atlas = ExtResource( 4 )
-region = Rect2( 118, 0, 59, 59 )
+region = Rect2( 59, 0, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=16]
 atlas = ExtResource( 4 )
-region = Rect2( 177, 0, 59, 59 )
+region = Rect2( 118, 0, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=17]
 atlas = ExtResource( 4 )
-region = Rect2( 236, 0, 59, 59 )
+region = Rect2( 177, 0, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=18]
 atlas = ExtResource( 4 )
-region = Rect2( 0, 59, 59, 59 )
+region = Rect2( 236, 0, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=19]
 atlas = ExtResource( 4 )
-region = Rect2( 59, 59, 59, 59 )
+region = Rect2( 0, 59, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=20]
 atlas = ExtResource( 4 )
-region = Rect2( 118, 59, 59, 59 )
+region = Rect2( 59, 59, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=21]
 atlas = ExtResource( 4 )
-region = Rect2( 177, 59, 59, 59 )
+region = Rect2( 118, 59, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=22]
 atlas = ExtResource( 4 )
-region = Rect2( 236, 59, 59, 59 )
+region = Rect2( 177, 59, 59, 59 )
 
 [sub_resource type="AtlasTexture" id=23]
-atlas = ExtResource( 3 )
-region = Rect2( 192, 136, 64, 68 )
+atlas = ExtResource( 4 )
+region = Rect2( 236, 59, 59, 59 )
 
 [sub_resource type="SpriteFrames" id=24]
 animations = [ {
@@ -107,20 +107,20 @@ animations = [ {
 "name": "jump",
 "speed": 5.0
 }, {
-"frames": [ SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ), SubResource( 12 ), SubResource( 11 ), SubResource( 10 ), SubResource( 9 ), SubResource( 8 ) ],
+"frames": [ SubResource( 7 ) ],
+"loop": true,
+"name": "airborne",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ), SubResource( 12 ), SubResource( 13 ), SubResource( 12 ), SubResource( 11 ), SubResource( 10 ), SubResource( 9 ) ],
 "loop": true,
 "name": "walk",
 "speed": 12.0
 }, {
-"frames": [ SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ) ],
+"frames": [ SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ) ],
 "loop": false,
 "name": "die",
 "speed": 20.0
-}, {
-"frames": [ SubResource( 23 ) ],
-"loop": true,
-"name": "airborne",
-"speed": 5.0
 } ]
 
 [node name="Kinematic2D" type="KinematicBody2D"]

--- a/Levels/Level.gd
+++ b/Levels/Level.gd
@@ -14,14 +14,20 @@ var sceneMap = {
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+    $Camera2D.current = false
     pass # Replace with function body.
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#    pass
+func _process(delta):
+    pass
 
 
 func _on_Boss_boss_killed():
     print("boss killed")
     get_tree().change_scene(sceneMap[get_tree().current_scene.name])
+
+
+func _on_Player_player_killed(camera_position):
+    $Camera2D.position = camera_position
+    $Camera2D.current = true

--- a/Levels/Level.tscn
+++ b/Levels/Level.tscn
@@ -76,9 +76,12 @@ scale = Vector2( -61.8083, -4.77283 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Kill Floor"]
 position = Vector2( 0, -39.5991 )
 shape = SubResource( 3 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
 [connection signal="body_entered" from="BossArena" to="GUI" method="_on_BossArena_body_entered"]
 [connection signal="body_exited" from="BossArena" to="GUI" method="_on_BossArena_body_exited"]
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="player_killed" from="Player" to="." method="_on_Player_player_killed"]
 [connection signal="boss_killed" from="Boss" to="." method="_on_Boss_boss_killed"]
 [connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]
 [connection signal="area_entered" from="Kill Floor" to="Player" method="_on_Kill_Floor_area_entered"]

--- a/Levels/Level1.tscn
+++ b/Levels/Level1.tscn
@@ -79,7 +79,12 @@ collision_mask = 5
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="BossArena"]
 polygon = PoolVector2Array( -14.2405, 690.458, 1455.13, 693.287, 1460, 1022.67, 1502.04, 1023.33, 1504.05, 1096.08, -10.4035, 1103.04 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+drag_margin_h_enabled = true
+drag_margin_v_enabled = true
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="player_killed" from="Player" to="." method="_on_Player_player_killed"]
 [connection signal="boss_killed" from="Boss" to="." method="_on_Boss_boss_killed"]
 [connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]
 [connection signal="powerup" from="RedPowerUp" to="Player" method="_on_RedPowerUp_powerup"]

--- a/Levels/LevelBattlefield.tscn
+++ b/Levels/LevelBattlefield.tscn
@@ -15,6 +15,7 @@ tile_data = PoolIntArray( 196614, 0, 5, 196615, 0, 6, 196616, 0, 6, 196617, 0, 7
 position = Vector2( 531.687, 428.373 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 4 )]
+pause_mode = 2
 
 [node name="GUI" parent="." instance=ExtResource( 3 )]
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]


### PR DESCRIPTION
This is done by adding a second camera node as a child of the level. On
player death, the player camera's coordinates are passed to the level
camera, which is then set to be the current camera. For future levels
this requires setting up a camera2d in the level, and connecting the
player's player_killed signal to the level script.