### PR TITLE
Add a death screen with a restart button

### DIFF
--- a/DeathScreen.gd
+++ b/DeathScreen.gd
@@ -1,0 +1,28 @@
+extends CanvasLayer
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+    $Control.hide()
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#    pass
+
+
+func _on_Button_button_down():
+    get_tree().change_scene("res://Levels/Level1.tscn")
+
+
+func _on_level_start():
+    $Control.hide()
+
+
+func _on_player_killed(_camera_position):
+    $Control.show()

--- a/DeathScreen.tscn
+++ b/DeathScreen.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://assets/fonts/Xolonium-Regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://DeathScreen.gd" type="Script" id=2]
+
+[sub_resource type="DynamicFont" id=1]
+size = 48
+font_data = ExtResource( 1 )
+
+[node name="DeathScreen" type="CanvasLayer"]
+script = ExtResource( 2 )
+
+[node name="Control" type="Control" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -20.0
+margin_top = -20.0
+margin_right = 20.0
+margin_bottom = 20.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Polygon2D" type="Polygon2D" parent="Control"]
+color = Color( 0, 0, 0, 0.682353 )
+polygon = PoolVector2Array( -940, -520, 980, -520, 980, 560, -940, 560 )
+
+[node name="Node2D" type="Node2D" parent="Control"]
+z_index = 1
+
+[node name="Button" type="Button" parent="Control/Node2D"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -104.0
+margin_top = -24.0
+margin_right = 144.0
+margin_bottom = 64.0
+custom_fonts/font = SubResource( 1 )
+text = "Restart"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+[connection signal="button_down" from="Control/Node2D/Button" to="." method="_on_Button_button_down"]

--- a/Levels/Level.gd
+++ b/Levels/Level.gd
@@ -5,6 +5,8 @@ extends Node2D
 # var a = 2
 # var b = "text"
 
+signal level_start
+
 var sceneMap = {
     "Level": "res://Levels/Level1.tscn",
     "Level 1": "res://Levels/Level.tscn",
@@ -15,6 +17,7 @@ var sceneMap = {
 # Called when the node enters the scene tree for the first time.
 func _ready():
     $Camera2D.current = false
+    emit_signal("level_start")
     pass # Replace with function body.
 
 

--- a/Levels/Level.tscn
+++ b/Levels/Level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://Actors/Characters/Player/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Platforms/Platforms.tscn" type="PackedScene" id=2]
+[ext_resource path="res://DeathScreen.tscn" type="PackedScene" id=3]
 [ext_resource path="res://Floor.tscn" type="PackedScene" id=4]
 [ext_resource path="res://PauseMenu.tscn" type="PackedScene" id=6]
 [ext_resource path="res://Actors/Characters/Enemy/Boss1.tscn" type="PackedScene" id=7]
@@ -78,9 +79,13 @@ position = Vector2( 0, -39.5991 )
 shape = SubResource( 3 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
+
+[node name="DeathScreen" parent="." instance=ExtResource( 3 )]
+[connection signal="level_start" from="." to="DeathScreen" method="_on_level_start"]
 [connection signal="body_entered" from="BossArena" to="GUI" method="_on_BossArena_body_entered"]
 [connection signal="body_exited" from="BossArena" to="GUI" method="_on_BossArena_body_exited"]
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="player_killed" from="Player" to="DeathScreen" method="_on_player_killed"]
 [connection signal="player_killed" from="Player" to="." method="_on_Player_player_killed"]
 [connection signal="boss_killed" from="Boss" to="." method="_on_Boss_boss_killed"]
 [connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]

--- a/Levels/Level1.tscn
+++ b/Levels/Level1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://Floor.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Actors/Characters/Enemy/Enemy.tscn" type="PackedScene" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://GUI.tscn" type="PackedScene" id=7]
 [ext_resource path="res://PauseMenu.tscn" type="PackedScene" id=8]
 [ext_resource path="res://Levels/Level.gd" type="Script" id=9]
+[ext_resource path="res://DeathScreen.tscn" type="PackedScene" id=10]
 
 [sub_resource type="Animation" id=1]
 resource_name = "move"
@@ -83,7 +84,11 @@ polygon = PoolVector2Array( -14.2405, 690.458, 1455.13, 693.287, 1460, 1022.67, 
 [node name="Camera2D" type="Camera2D" parent="."]
 drag_margin_h_enabled = true
 drag_margin_v_enabled = true
+
+[node name="DeathScreen" parent="." instance=ExtResource( 10 )]
+[connection signal="level_start" from="." to="DeathScreen" method="_on_level_start"]
 [connection signal="health_changed" from="Player" to="GUI" method="_on_Player_health_changed"]
+[connection signal="player_killed" from="Player" to="DeathScreen" method="_on_player_killed"]
 [connection signal="player_killed" from="Player" to="." method="_on_Player_player_killed"]
 [connection signal="boss_killed" from="Boss" to="." method="_on_Boss_boss_killed"]
 [connection signal="health_changed" from="Boss" to="GUI" method="_on_Boss_health_changed"]


### PR DESCRIPTION
The restart button currently is hardcoded to change scenes to level1. In
order to hook it up correctly, the level signal "level_start" must be
attached to the death screen script on_level_start func, and the
player's player_killed signal must be attached to the death screen's
on_player_killed func.